### PR TITLE
Bugfixes for duplicate menus and games with only human players ending prematurely

### DIFF
--- a/lua/entities/ent_poker_game/cl_init.lua
+++ b/lua/entities/ent_poker_game/cl_init.lua
@@ -796,6 +796,12 @@ end
 
 
 function ENT:openLeaveRequest()
+
+	self.leaveRequested = self.leaveRequested or false
+
+	if self.leaveRequested then return
+	else self.leaveRequested = true end
+
     local w, h = 200, 120
     local win = vgui.Create("DFrame")
     win:SetSize(w,h)
@@ -838,6 +844,7 @@ function ENT:openLeaveRequest()
         surface.DrawOutlinedRect(0,0,w,h,buttonOutline)
     end
     y.DoClick = function()
+		self.leaveRequested = false
         win:Close()
 
         if !IsValid(self) then return end
@@ -866,6 +873,7 @@ function ENT:openLeaveRequest()
         surface.DrawOutlinedRect(0,0,w,h,buttonOutline)
     end
     n.DoClick = function()
+		self.leaveRequested = false
         if self:GetTurn() == self:getPlayerKey(LocalPlayer()) then 
             if gPoker.gameType[self:GetGameType()].states[self:GetGameState()].drawing then
                 self:openExchangeDerma()

--- a/lua/entities/ent_poker_game/init.lua
+++ b/lua/entities/ent_poker_game/init.lua
@@ -1246,7 +1246,9 @@ function ENT:prepareForRestart()
         end
     end
 
-    if self:getPlayersAmount() > 0 and (self:GetBots() > 0 and self:getBotsAmount() > 0) then self:SetGameState(0) else
+    if self:getPlayersAmount() > 1 or (self:getPlayersAmount() == 1 and self:GetBots() > 0 and self:getBotsAmount() > 0) then
+		self:SetGameState(0)
+	else
         if self:getPlayersAmount() > 0 then
             for k,v in pairs(self.players) do
                 if !v.bot then self:removePlayerFromMatch(Entity(v.ind)) end


### PR DESCRIPTION
Fixing a few bugs I ran into.

The openLeaveRequest menu opens when it detects a player has used the table while sitting at it, but I noticed it spawned 6-7 menus at a time, requiring multiple clicks to close them all.

I also noticed that the prepareForRestart method doesn't work properly if there are only humans in the game, so I fixed that too.