### PR TITLE
Fix bug where record x; stop breaks the poker table

### DIFF
--- a/lua/entities/ent_poker_game/cl_init.lua
+++ b/lua/entities/ent_poker_game/cl_init.lua
@@ -280,11 +280,27 @@ end
 
 
 
-function ENT:OnRemove()
-    if IsValid(self.deckPot) then self.deckPot:Remove() end
-    if IsValid(self.dealer) then self.dealer:Remove() end
-
-    hook.Remove("HUDPaint", "gpoker_hudPaint" .. self:EntIndex())
+function ENT:OnRemove(fullUpdate)
+	-- Fixes issue where record x; stop would prevent the HUD from showing up
+	-- and cause the deck/dealer chip to teleport to the map origin
+	if fullUpdate then
+		timer.Simple( 0, function()
+			if IsValid(self.deckPot) then
+				self.deckPot:SetParent(self)
+				self.deckPot:SetLocalPos(self.deckPot:GetLocalPos())
+				self.deckPot:SetLocalAngles(self.deckPot:GetLocalAngles())
+			end
+			if IsValid(self.dealer) then
+				self.dealer:SetParent(self)
+				self.dealer:SetLocalPos(self.dealer:GetLocalPos())
+				self.dealer:SetLocalAngles(self.dealer:GetLocalAngles())
+			end
+		end )
+	else
+		if IsValid(self.deckPot) then self.deckPot:Remove() end
+		if IsValid(self.dealer) then self.dealer:Remove() end
+		hook.Remove("HUDPaint", "gpoker_hudPaint" .. self:EntIndex())
+	end
 end
 
 


### PR DESCRIPTION
record x; stop resets all entities with models on the client and is used extensively by Outfitter/Wardrobe to refresh client models. This causes the OnRemove method to be fired, which will break the HUD on any currently spawned tables and cause the pot/dealer chip to get teleported to the map's origin point. The former makes the game basically unplayable unless the table is recreated.

OnRemove has an argument, fullUpdate, that is true when a recording is ending. When this is true, we can prevent the HUDDraw hook from being removed (which fixes the HUD) and reset the entities on the table to their original positions.